### PR TITLE
Fix `mRLN` mutator typechecking issue

### DIFF
--- a/mutator/mutations/mRLN.py
+++ b/mutator/mutations/mRLN.py
@@ -29,7 +29,7 @@ class mRLN(Base):
         return modified_tree
 
     def __generate_random_number(self, node: libcst.CSTNode) -> int | float:
-        if node is libcst.Integer:
+        if type(node) is libcst.Integer:
             return self.__generate_random_integer()
         else:
             return self.__generate_random_float()

--- a/mutator/transformers/literal_value_transformer.py
+++ b/mutator/transformers/literal_value_transformer.py
@@ -14,7 +14,7 @@ class LiteralValueTransformer(libcst.CSTTransformer):
         self, original_node: libcst.Integer, updated_node: libcst.Integer
     ) -> libcst.Integer:
         modified_node = self.__try_update_node(original_node, updated_node)
-        if modified_node is not libcst.Integer:
+        if type(modified_node) is not libcst.Integer:
             raise RuntimeError(
                 "Unexpected returned value type, expected `libcst.Integer`"
             )
@@ -25,7 +25,7 @@ class LiteralValueTransformer(libcst.CSTTransformer):
         self, original_node: libcst.Float, updated_node: libcst.Float
     ) -> libcst.Float:
         modified_node = self.__try_update_node(original_node, updated_node)
-        if modified_node is not libcst.Float:
+        if type(modified_node) is not libcst.Float:
             raise RuntimeError(
                 "Unexpected returned value type, expected `libcst.Float`"
             )
@@ -36,7 +36,7 @@ class LiteralValueTransformer(libcst.CSTTransformer):
         self, original_node: libcst.SimpleString, updated_node: libcst.SimpleString
     ) -> libcst.SimpleString:
         modified_node = self.__try_update_node(original_node, updated_node)
-        if modified_node is not libcst.SimpleString:
+        if type(modified_node) is not libcst.SimpleString:
             raise RuntimeError(
                 "Unexpected returned value type, expected `libcst.SimpleString`"
             )


### PR DESCRIPTION
Fixes typos a la

```python
node is libcst.CSTNode
```

->

```python
type(node) is libcst.CSTNode
```